### PR TITLE
Add empty src/Version directory required by default build process

### DIFF
--- a/src/Version/.gitignore
+++ b/src/Version/.gitignore
@@ -1,0 +1,1 @@
+!.gitignore


### PR DESCRIPTION
Would this fix it?

It adds a .gitignore file that tells it to ignore everything in this directory, except itself, that way the directory will get commited even though it may be empty
